### PR TITLE
provide script option that does not disable eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
+    "start-windows": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
very simple fix for @sburchfield33 's issue on windows


**TESTING PLAN**
run "npm run start-windows" and ensure application works properly

![image](https://github.com/HongjieWang98/TEN-techteam-coworking/assets/22818710/6e8e6821-70d9-4581-867e-51ca1f3a9f65)
