### PR TITLE
[feature] handle buyer and seller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3027,15 +3027,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
-      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.14",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",

--- a/src/api/process_textbook.js
+++ b/src/api/process_textbook.js
@@ -53,8 +53,11 @@ export const EventStatus = {
 /**
  * Represents a textbook (only typing the fields necessary for processTextbook)
  * @typedef {Object} Textbook
+ * @property {string} id
  * @property {User} seller
  * @property {User} buyer
+ * @property {string} seller_id
+ * @property {string} buyer_id
  * @property {EventStatusType} status
  */
 

--- a/src/api/process_textbook.js
+++ b/src/api/process_textbook.js
@@ -23,7 +23,7 @@ const EventType = {
 /**
  * @enum {string}
  */
-const EventStatus = {
+export const EventStatus = {
   ACTIVE: 'active',
   REMOVED: 'removed',
   RESERVED: 'reserved',

--- a/src/api/process_textbook.js
+++ b/src/api/process_textbook.js
@@ -91,13 +91,13 @@ export async function processTextbook(textbookRef, textbook, includeSellerBuyerS
   const mostRecentTextbookEvent = textbookEvents[0];
   const textbookStatus = evaluateEventStatus(mostRecentTextbookEvent);
   const seller_id = textbook.seller_id;
-  const buyer_id = textbook.buyer_id;
+  let buyer_id = textbook.buyer_id;
   const nullifyBuyerForTextbookIds = [];
 
   // Since the buyer can be removed from the textbook in the case their reservation 
   // expires or the listing is removed, we need to nullify the buyer
-  if (textbookStatus === EventStatus.REMOVED || 
-    textbookStatus === EventStatus.ACTIVE
+  if ((textbookStatus === EventStatus.REMOVED || 
+    textbookStatus === EventStatus.ACTIVE) && buyer_id
   ) {
     buyer_id = null;
     nullifyBuyerForTextbookIds.push(textbookRef.id);

--- a/src/api/textbook.js
+++ b/src/api/textbook.js
@@ -19,10 +19,7 @@ export async function getTextbookById(id) {
   const textbook = await getDoc(textbookDocRef);
 
   if (textbook.exists()) {
-    return {
-      id: textbook.id,
-      ...(await processTextbook(textbookDocRef, textbook.data()))
-    };
+    return await processTextbook(textbook.ref, textbook.data(), includeSellerBuyerSubmodel)
   }
 
   return null;
@@ -33,14 +30,11 @@ export async function getTextbooksByUserId(userId) {
   const q = query(textbookCollectionRef, or(where('seller_id', '==', userId), where('buyer_id', '==', userId)));
   const textbooks = (await getDocs(q)).docs;
 
-  return Promise.all(
+  return (await Promise.all(
     textbooks.map(async (textbook) => {
-      return {
-        id: textbook.id,
-        ...(await processTextbook(textbook.ref, textbook.data()))
-      };
+      return await processTextbook(textbook.ref, textbook.data())
     })
-  );
+  )).filter((textbook) => textbook.seller_id === userId || textbook.buyer_id === userId);
 }
 
 export async function getTextbooksByOrganizationId(organizationId) {
@@ -49,7 +43,9 @@ export async function getTextbooksByOrganizationId(organizationId) {
   const q = query(textbookCollectionRef, where('organization_id', '==', organizationId));
   const textbooks = (await getDocs(q)).docs;
 
-  return Promise.all(textbooks.map(async (textbook) => getTextbookById(textbook.id)));
+  return Promise.all(textbooks.map(async (textbook) => {
+    return await processTextbook(textbook.ref, textbook.data())
+  }));
 }
 
 // we should handle any race conditions that comes with textbook events

--- a/src/api/textbook.js
+++ b/src/api/textbook.js
@@ -11,7 +11,7 @@ import {
   serverTimestamp
 } from 'firebase/firestore/lite';
 import { db } from '../firebase/firebase_config';
-import { processTextbook } from './process_textbook';
+import { EventStatus, processTextbook } from './process_textbook';
 
 export async function getTextbookById(id) {
   const textbookCollectionRef = collection(db, 'textbooks');
@@ -78,9 +78,7 @@ export async function reserveTextbooks(textbooks, userId) {
     textbooks.map(async (textbook) => {
       try {
         const currTextbook = await getTextbookById(textbook.id);
-        if (currTextbook != null && currTextbook.status === 'active') {
-          const textbookCollectionRef = collection(db, 'textbooks');
-          await updateDoc(doc(textbookCollectionRef, textbook.id), { buyer_id: userId });
+        if (currTextbook != null && currTextbook.status === EventStatus.ACTIVE) {
           const subcollectionRef = collection(db, `textbooks/${textbook.id}/textbook_events`);
           const currTime = serverTimestamp();
           await addDoc(subcollectionRef, {

--- a/src/api/textbook.js
+++ b/src/api/textbook.js
@@ -46,7 +46,7 @@ export async function getTextbooksByUserId(userId) {
 export async function getTextbooksByOrganizationId(organizationId) {
   // TODO put some caching here
   const textbookCollectionRef = collection(db, 'textbooks');
-  const q = query(textbookCollectionRef, where('orgazation_id', '==', organizationId));
+  const q = query(textbookCollectionRef, where('organization_id', '==', organizationId));
   const textbooks = (await getDocs(q)).docs;
 
   return Promise.all(textbooks.map(async (textbook) => getTextbookById(textbook.id)));

--- a/src/components/Buy/BuySuccessPage.jsx
+++ b/src/components/Buy/BuySuccessPage.jsx
@@ -4,7 +4,6 @@ function BuySuccessPage() {
   const location = useLocation();
   const { state } = location;
   const { bookReserve } = state || {}; // Extract bookReserve from state
-  console.log('bookReserve', bookReserve);
   return (
     <>
       <h1>Textbook Reserve Report</h1>
@@ -12,7 +11,6 @@ function BuySuccessPage() {
         <>
           <h1>Textbooks Bought {bookReserve.length}</h1>
           {bookReserve.map((textbook) => {
-            console.log(textbook.title, textbook.bought);
             return <h1 key={textbook.id}>{textbook.title}</h1>;
           })}
         </>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -36,6 +36,17 @@ export function AuthProvider({ children }) {
     setCurrentUser(null);
   }
 
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged(async (user) => {
+      if (user) {
+        setCurrentUser(await getUserById(user.uid));
+        setCurrentAuthUser(user);
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value = {
     currentUser,

--- a/src/pages/Listing/ViewListingPage.jsx
+++ b/src/pages/Listing/ViewListingPage.jsx
@@ -19,9 +19,9 @@ function ViewListingPage() {
         // do something with bad listing id
       }
 
-      if (listingDetails.buyer_id === userId) {
+      if (listingDetails.buyer?.id === userId) {
         setListingComponent(<BuyerListing listingData={listingDetails} />);
-      } else if (listingDetails.seller_id === userId) {
+      } else if (listingDetails.seller.id === userId) {
         setListingComponent(<SellerListing listingData={listingDetails} />);
       }
     }

--- a/src/pages/Listing/ViewListingPage.jsx
+++ b/src/pages/Listing/ViewListingPage.jsx
@@ -14,14 +14,14 @@ function ViewListingPage() {
     const userId = currentUser?.id;
 
     async function fetchDataAndSetComponent() {
-      const listingDetails = await getTextbookById(listingId);
+      const listingDetails = await getTextbookById(listingId, true);
       if (!listingDetails) {
         // do something with bad listing id
       }
 
-      if (listingDetails.buyer?.id === userId) {
+      if (listingDetails.buyer_id === userId) {
         setListingComponent(<BuyerListing listingData={listingDetails} />);
-      } else if (listingDetails.seller.id === userId) {
+      } else if (listingDetails.seller_id === userId) {
         setListingComponent(<SellerListing listingData={listingDetails} />);
       }
     }

--- a/src/pages/Sell/ListingPage.jsx
+++ b/src/pages/Sell/ListingPage.jsx
@@ -32,20 +32,21 @@ export default function ListingPage() {
 
       try {
         // server side validation needed
-        await listTextbook({
-          isbn: data['isbn'],
-          title: data['title'],
-          author: data['author'],
-          edition: data['edition'],
-          department: data['department'],
-          course_number: data['courseNumber'],
-          price: data['price'],
-          notes: data['notes'],
-          condition: condition,
-          seller_id: currentUser.id,
-          buyer_id: null,
-          orgazation_id: currentUser.organization_id
-       });
+        await listTextbook(
+          {
+            isbn: data['isbn'],
+            title: data['title'],
+            author: data['author'],
+            edition: data['edition'],
+            department: data['department'],
+            course_number: data['courseNumber'],
+            price: data['price'],
+            notes: data['notes'],
+            condition: condition,
+            organization_id: currentUser.organization_id
+          },
+          currentUser.id
+        );
         navigate('/sell/confirmation/');
       } catch (error) {
         console.error('Error uploading data to database: ', error);

--- a/src/pages/Sell/ListingPage.jsx
+++ b/src/pages/Sell/ListingPage.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { listTextbook } from '../../api/textbook';
 import { Form, Button, Card, Alert, Container, Row, Col } from 'react-bootstrap';
-import './ListingPage.css'
+import './ListingPage.css';
 
 export default function ListingPage() {
   const [condition, setCondition] = useState('');
@@ -74,7 +74,14 @@ export default function ListingPage() {
           <Col md={8}>
             <Row className="form-row">
               <Col md={12}>
-                <Input name="isbn" label="ISBN" placeholder="978123345488777" type="number" isLoading={isLoading} required />
+                <Input
+                  name="isbn"
+                  label="ISBN"
+                  placeholder="978123345488777"
+                  type="number"
+                  isLoading={isLoading}
+                  required
+                />
               </Col>
             </Row>
             <Row className="form-row">
@@ -97,10 +104,24 @@ export default function ListingPage() {
             </Row>
             <Row className="form-row">
               <Col md={4}>
-                <Input name="department" label="Department" placeholder="BIO" type="text" isLoading={isLoading} required />
+                <Input
+                  name="department"
+                  label="Department"
+                  placeholder="BIO"
+                  type="text"
+                  isLoading={isLoading}
+                  required
+                />
               </Col>
               <Col md={4}>
-                <Input name="courseNumber" label="Course Number" placeholder="1" type="text" isLoading={isLoading} required />
+                <Input
+                  name="courseNumber"
+                  label="Course Number"
+                  placeholder="1"
+                  type="text"
+                  isLoading={isLoading}
+                  required
+                />
               </Col>
               <Col md={4}>
                 <Input name="price" label="Price" placeholder="10" type="number" isLoading={isLoading} required />
@@ -131,12 +152,13 @@ export default function ListingPage() {
                 />
               </Col>
             </Row>
-            <Row className="justify-content-center"> 
+            <Row className="justify-content-center">
               <Button type="submit" disabled={isLoading} className="btn btn-primary w-100 mt-2 mx-auto">
-              Submit Listing
+                Submit Listing
               </Button>
               <div className="w-100 text-center mt-2">
-                By continuing, you accept our <a href="/privacy">privacy policy</a> and <a href="/terms">terms and conditions</a>.
+                By continuing, you accept our <a href="/privacy">privacy policy</a> and{' '}
+                <a href="/terms">terms and conditions</a>.
               </div>
             </Row>
           </Col>


### PR DESCRIPTION
We will be including the seller_id and buyer_id info at the textbook collection level because if we try to derive that info from the textbook_events, it gets very messy when trying to get textbooks by user_id.

Including some other changes:
- keep user signed in on page refresh
- include option to get user submodel when processing textbook
- some other misc. cleanup